### PR TITLE
feat: Add navigation link for JSON Editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,12 @@
 					<div class="col-60 d-flex justify-content-center">
 						<nav id="main-menu">
 							<ul>
-								<li class="current"><a href="index.html">Home</a></li>							  				  
-                                <li><a href="tools.html">Free Tools</a></li>
+								<li class="current"><a href="index.html">Home</a></li>
+                                <li><a href="tools.html">Free Tools</a>
+									<ul class="sub-menu">
+										<li><a href="json_editor.html">JSON Editor</a></li>
+									</ul>
+								</li>
 								<li><a href="contact.html">Contact</a></li>
 							</ul>
 						</nav>
@@ -73,8 +77,12 @@
 					</div><!--- END Col -->
 					
 					<ul class="mobile_menu">						
-						<li><a href="index.html">Home</a></li>							  				  
-                        <li><a href="tools.html">Free Tools</a></li>
+						<li><a href="index.html">Home</a></li>
+                        <li><a href="tools.html">Free Tools</a>
+							<ul class="sub-menu">
+								<li><a href="json_editor.html">JSON Editor</a></li>
+							</ul>
+						</li>
 						<li><a href="contact.html">Contact</a></li>
 					</ul>			
 				</div><!--- END ROW -->


### PR DESCRIPTION
Adds a link to the `json_editor.html` page in the main navigation menu and mobile menu of `index.html`.

The link is placed as a sub-menu item under 'Free Tools'.