### PR TITLE
fix: Remove 'Learn More' buttons from Core Competencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,6 @@
 									<div class="icon"><img src="assets/img/icons/performance-marketing.svg" alt="Performance Marketing Icon"></div>
 									<h5>Performance Marketing & Revenue Growth</h5>
 									<p>Driving significant revenue through data-backed performance funnels and GTM strategies.</p>
-									<a href="about.html#competencies" class="read-more-btn">Learn More <i class='bx bx-right-arrow-alt'></i></a>
 								</div>
 							</div>
 							<div class="col-xl-4 col-md-6 col-12">
@@ -207,7 +206,6 @@
 									<div class="icon"><img src="assets/img/icons/seo-ui.svg" alt="SEO & UI Optimization Icon"></div>
 									<h5>SEO & UI Optimization</h5>
 									<p>Enhancing online visibility and user engagement with technical SEO and strategic UI/UX.</p>
-									<a href="about.html#competencies" class="read-more-btn">Learn More <i class='bx bx-right-arrow-alt'></i></a>
 								</div>
 							</div>
 							<div class="col-xl-4 col-md-6 col-12">
@@ -215,7 +213,6 @@
 									<div class="icon"><img src="assets/img/icons/automation-crm.svg" alt="Automation & CRM Integration Icon"></div>
 									<h5>Automation & CRM Integration</h5>
 									<p>Building efficient marketing systems with email sequencing, CRM workflows, and omnichannel automation.</p>
-									<a href="about.html#competencies" class="read-more-btn">Learn More <i class='bx bx-right-arrow-alt'></i></a>
 								</div>
 							</div>
 							<div class="col-xl-4 col-md-6 col-12">
@@ -223,7 +220,6 @@
 									<div class="icon"><img src="assets/img/icons/social-video.svg" alt="Social & Video Branding Icon"></div>
 									<h5>Social & Video Branding</h5>
 									<p>Scaling brand presence and engagement across social platforms with compelling video content.</p>
-									<a href="about.html#competencies" class="read-more-btn">Learn More <i class='bx bx-right-arrow-alt'></i></a>
 								</div>
 							</div>
 							<div class="col-xl-4 col-md-6 col-12">


### PR DESCRIPTION
Removes the 'Learn More' anchor tags from the first four items in the 'Core Competencies' section of index.html:
- Performance Marketing & Revenue Growth
- SEO & UI Optimization
- Automation & CRM Integration
- Social & Video Branding