### PR TITLE
Remove redundant Core Competencies section

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,54 +190,6 @@
 							</p>
 						</div>
 					</div><!-- End Col -->					
-					
-					<div class="col-xl-12 col-md-12 col-12 wow fadeIn mt-5">
-						<h4 class="subtitle text-center">Core Competencies</h4>
-						<div class="row">
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp">
-									<div class="icon"><img src="assets/img/icons/performance-marketing.svg" alt="Performance Marketing & Revenue Growth Icon"></div>
-									<h5>Performance Marketing & Revenue Growth</h5>
-									<p>Driving significant revenue through data-backed performance funnels and GTM strategies.</p>
-								</div>
-							</div>
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp" data-wow-delay="0.1s">
-									<div class="icon"><img src="assets/img/icons/seo-ui-optimization.svg" alt="SEO & UI Optimization Icon"></div>
-									<h5>SEO & UI Optimization</h5>
-									<p>Enhancing online visibility and user engagement with technical SEO and strategic UI/UX.</p>
-								</div>
-							</div>
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp" data-wow-delay="0.2s">
-									<div class="icon"><img src="assets/img/icons/automation-crm-integration.svg" alt="Automation & CRM Integration Icon"></div>
-									<h5>Automation & CRM Integration</h5>
-									<p>Building efficient marketing systems with email sequencing, CRM workflows, and omnichannel automation.</p>
-								</div>
-							</div>
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp" data-wow-delay="0.3s">
-									<div class="icon"><img src="assets/img/icons/social-video-branding.svg" alt="Social & Video Branding Icon"></div>
-									<h5>Social & Video Branding</h5>
-									<p>Scaling brand presence and engagement across social platforms with compelling video content.</p>
-								</div>
-							</div>
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp" data-wow-delay="0.4s">
-									<div class="icon"><img src="assets/img/icons/podcasting-audio-automation.svg" alt="Podcasting & Audio Automation Icon"></div>
-									<h5>Podcasting & Audio Automation</h5>
-									<p>Crafting engaging audio experiences and knowledge hubs with automated podcast production.</p>
-								</div>
-							</div>
-							<div class="col-xl-4 col-md-6 col-12">
-								<div class="competency-card wow fadeInUp" data-wow-delay="0.5s">
-									<div class="icon"><img src="assets/img/icons/bootcamps-training-community.svg" alt="Bootcamps, Training & Community Building Icon"></div>
-									<h5>Bootcamps, Training & Community Building</h5>
-									<p>Empowering professionals and building communities through targeted training programs.</p>
-								</div>
-							</div>
-						</div>
-					</div><!-- End Col -->
 				</div>
 				
 				<div class="row section-padding">


### PR DESCRIPTION
This commit removes the first of two 'Core Competencies' sections from the index.html page. The removed section was located between the 'About Me' and 'Career Highlights' sections.