### PR TITLE
I've fixed the counter animation issues and refined the logic. Here's…

### DIFF
--- a/index.html
+++ b/index.html
@@ -865,7 +865,7 @@
 		<!-- waypoints -->
 		<script src="assets/js/waypoints.min.js"></script>		
 		<!-- counterup -->
-		<script src="assets/js/jquery.counterup.min.js"></script>
+		<!-- <script src="assets/js/jquery.counterup.min.js"></script> --> <!-- Commented out to prevent conflict -->
 		<!-- jquery appear js -->			
 		<script src="assets/js/jquery.appear.js"></script>
 		<!-- magnific-popup js -->	


### PR DESCRIPTION
… what I did:

- I commented out conflicting jquery.counterup.min.js in index.html to allow the custom animation to take precedence.
- I adjusted the Waypoint offset for counters in scripts.js to 90% to trigger the animation sooner.
- I refactored the Waypoint initialization to correctly target individual .single-counter containers, ensuring each animates independently and only once.
- I ensured the animation starts from the numeric value of the HTML text (the 'incorrect' starting value) and animates towards the data-count value.
- I added a defensive line to set the h4 text to the formatted initial numeric value just before the animation starts, preventing potential flickers.
- I verified the step and complete functions correctly format numbers during animation and set the final base number accurately.