### PR TITLE
Fix: Animate counters from 0 and handle M+ suffixes

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -32,11 +32,6 @@ Version      : 1.0
 			// });
 
 			// New Counter using jquery.counterup.min.js and Waypoints
-			// Ensure the target elements for counterup have the final number as their text content initially
-			// or that counterup is configured to use data-count if it supports it.
-			// Standard counterup uses the text content.
-			// The HTML has <h4 class="counter-number" data-count="1000">1000</h4>
-			// So, we target ".single-counter" for waypoints for better structure
 			if ($('.single-counter').length) {
 				$('.single-counter').waypoint(function(direction) {
 					var $thisCounterContainer = $(this.element); // Current .single-counter div that hit waypoint
@@ -48,21 +43,27 @@ Version      : 1.0
 					// Find the h4.counter-number within this specific container
 					$thisCounterContainer.find('h4.counter-number').each(function() {
 						var $thisH4 = $(this); // The h4 element
-						var dataCountVal = $thisH4.attr('data-count'); // Target display number, e.g., "10", "1000"
-						var initialText = $thisH4.text(); // Initial "incorrect" text e.g., "10,000,000" or "1,000"
+						var dataCountValText = $thisH4.attr('data-count'); // e.g., "1000", "10", "1", "5"
+						var symbol = $thisH4.siblings('span.counter-symbol').text(); // e.g., "+", "M+"
 
-						var initialNumericValue = parseFloat(initialText.replace(/,/g, ''));
-						if (isNaN(initialNumericValue)) {
-							initialNumericValue = 0; // Fallback
+						var initialNumericValue = 0; // Always start from 0
+
+						var targetNumericValue = parseFloat(dataCountValText);
+						if (isNaN(targetNumericValue)) {
+							targetNumericValue = 0; // Fallback
 						}
 
-						var targetNumericValue = parseFloat(dataCountVal);
+						if (symbol.includes('M')) {
+							targetNumericValue *= 1000000;
+						} else if (symbol.includes('K')) { // Though not used in current HTML, good for robustness
+							targetNumericValue *= 1000;
+						}
 
-						// Explicitly set the starting text with formatting,
-						// in case of any delay before the first animation step.
-						$thisH4.text(initialNumericValue.toLocaleString());
+						// Explicitly set the starting text to 0 or initial formatted value if needed.
+						// Since we animate from 0, we can set it to 0.
+						$thisH4.text('0');
 
-						// Start animation from the initialNumericValue
+						// Start animation from 0
 						$({ countNum: initialNumericValue }).animate({
 							countNum: targetNumericValue
 						  },
@@ -71,10 +72,12 @@ Version      : 1.0
 							easing:'linear',
 							step: function() {
 							  let currentStepVal = Math.floor(this.countNum);
+							  // Display with locale string for commas, but without symbol during animation.
 							  $thisH4.text(currentStepVal.toLocaleString());
 							},
 							complete: function() {
-							  $thisH4.text(dataCountVal);
+							  // On complete, show the original text representation + symbol
+							  $thisH4.text(dataCountValText + symbol);
 							  $thisCounterContainer.addClass('animated-counter'); // Add class to container
 							}
 						  });


### PR DESCRIPTION
- I modified assets/js/scripts.js to ensure counter animations start from 0.
- I implemented logic to correctly parse `data-count` attributes and associated symbols (e.g., 'M+' for millions) to determine the correct numerical animation target.
- I ensured that the final displayed text after animation correctly combines the base number and its symbol (e.g., '10M+').