### PR TITLE
Feat: Re-implement counter animation from 0 to target values

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -31,6 +31,77 @@ Version      : 1.0
 			// 	  });
 			// });
 
+			// Counter Animation Logic
+			if ($('.single-counter').length) {
+				$('.single-counter').each(function() {
+					var $thisCounterContainer = $(this);
+					$thisCounterContainer.waypoint(function(direction) {
+						if ($thisCounterContainer.hasClass('animated-counter-v2')) {
+							return; // Already animated this container
+						}
+
+						$thisCounterContainer.find('h4.counter-number').each(function() {
+							var $thisH4 = $(this);
+							var originalFullText = $thisH4.text(); // e.g., "$10M+", "1000+", "5+"
+
+							// Regex to extract prefix (optional, like $), number, and suffix (optional, like M, K, +)
+							// It captures:
+							// 1. Optional non-digit prefix (e.g., "$")
+							// 2. The number part
+							// 3. The suffix part including M, K, + and any other characters
+							var parts = originalFullText.match(/^(\D*)(\d+)(.*)$/);
+
+							if (!parts) {
+								// If no match, it might be a simple number or something unexpected.
+								// Keep existing text and don't animate.
+								console.warn("Could not parse counter text:", originalFullText);
+								return;
+							}
+
+							var prefix = parts[1] || ""; // e.g., "$" or ""
+							var numberStr = parts[2];    // e.g., "10", "1000", "5"
+							var suffix = parts[3] || "";   // e.g., "M+", "+", ""
+
+							var targetNumericValue = parseFloat(numberStr);
+							if (isNaN(targetNumericValue)) {
+								console.warn("Parsed number is NaN for:", originalFullText);
+								return; // Skip if number is not valid
+							}
+
+							// Adjust target based on suffix
+							if (suffix.includes('M')) {
+								targetNumericValue *= 1000000;
+							} else if (suffix.includes('K')) {
+								targetNumericValue *= 1000;
+							}
+
+							// Set initial display
+							$thisH4.text(prefix + '0');
+
+							$({ countNum: 0 }).animate({
+								countNum: targetNumericValue
+							},
+							{
+								duration: 2000,
+								easing: 'linear',
+								step: function() {
+									let currentStepVal = Math.floor(this.countNum);
+									$thisH4.text(prefix + currentStepVal.toLocaleString());
+								},
+								complete: function() {
+									$thisH4.text(originalFullText); // Restore original full text
+									$thisCounterContainer.addClass('animated-counter-v2');
+								}
+							});
+						});
+					}, {
+						offset: '90%',
+						triggerOnce: true
+					});
+				});
+			}
+			/* End Counter Animation Logic */
+
 			/* Active Menu */
 			$(".mobile_menu").simpleMobileMenu({			
 				"menuStyle": "slide"


### PR DESCRIPTION
- I've added new JavaScript logic to animate counters when they scroll into view.
- The script parses the static text (e.g., "$10M+", "1000+") from the HTML to determine numerical targets, prefixes, and suffixes.
- Counters animate from 0 to the calculated numerical value, displaying any prefix and comma-separated numbers during animation.
- On completion, the exact original static text is restored.
- I've ensured animations run only once per element.