### PR TITLE
Refactor: Separate tools into individual pages (Phase 1)

### DIFF
--- a/assets/js/tools-page.js
+++ b/assets/js/tools-page.js
@@ -134,12 +134,16 @@ document.addEventListener('DOMContentLoaded', function () {
             const cardElement = document.createElement('div');
             cardElement.className = 'tool-card'; // Use the CSS class we defined
 
+            const toolPageName = tool.id ? tool.id.replace(/ToolSection$/, '.html').toLowerCase() : `${tool.name.toLowerCase().replace(/\s+/g, '-')}.html`;
+            const isImplemented = ['word-counter.html', 'json-validator.html', 'seo-meta-tag-checker.html'].includes(toolPageName);
+            const targetUrl = isImplemented ? toolPageName : (tool.url && tool.url.startsWith("#") ? 'coming-soon.html' : tool.url || 'coming-soon.html');
+
+
             cardElement.innerHTML = `
                 <h5>${tool.name}</h5>
                 <p>${tool.description}</p>
-                <button data-tool-id="${tool.id || tool.name.toLowerCase().replace(/\s+/g, '-')}" class="btn btn-use-now">Use Now</button>
+                <a href="${targetUrl}" class="btn btn-use-now">Use Now</a>
             `;
-            // Removed direct href, will handle navigation via JS
 
             cardWrapper.appendChild(cardElement);
             toolCardsContainer.appendChild(cardWrapper);
@@ -147,13 +151,16 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Initial display of all tools
-    if (toolCardsContainer && typeof toolsData !== 'undefined') {
+    if (toolCardsContainer && typeof toolsData !== 'undefined' && document.getElementById('toolCardsContainer')) { // Ensure this runs only on tools.html
         displayTools(toolsData);
     }
 
     // The filterTools function (defined above) will work by showing/hiding these generated cards.
 
-    // --- Word Counter Logic ---
+    // --- Word Counter Logic (and other tool specific logic) ---
+    // This logic should now only run if the relevant elements for each tool are present on the page.
+    // The existing `if (element)` checks before adding event listeners are good.
+
     const wordCounterInput = document.getElementById('wordCounterInput');
     const wordCountOutput = document.getElementById('wordCountOutput');
     const charCountOutput = document.getElementById('charCountOutput');
@@ -224,63 +231,20 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     // --- End Word Counter Logic ---
 
-    // --- Tool Navigation Logic ---
-    const allToolSections = document.querySelectorAll('.tool-content .row[id$="ToolSection"]'); // Selects all tool sections based on ID pattern
-    const backToToolsBtns = document.querySelectorAll('.back-to-tools-btn'); // Select all back buttons by class
+    // --- Tool Navigation Logic (Primarily for "Back to Tools" buttons on individual tool pages) ---
+    // The old logic for showing/hiding sections on tools.html is no longer needed here.
+    // The "Use Now" buttons on tools.html are now direct links.
 
-    function showToolSection(toolIdToShow) {
-        // Hide tool cards container and search bar
-        if (toolCardsContainer) toolCardsContainer.style.display = 'none';
-        if (searchInput) searchInput.closest('.row').style.display = 'none';
-
-        // Hide all tool sections
-        allToolSections.forEach(section => {
-            section.style.display = 'none';
-        });
-
-        // Show the selected tool section
-        const sectionToShow = document.getElementById(toolIdToShow);
-        if (sectionToShow) {
-            sectionToShow.style.display = 'block'; // Or 'flex' if it's a flex container (Bootstrap row)
-        } else {
-            console.warn(`Tool section with ID "${toolIdToShow}" not found.`);
-            showToolsList(); // Fallback to tools list if section not found
-        }
-    }
-
-    function showToolsList() {
-        // Hide all tool sections
-        allToolSections.forEach(section => {
-            section.style.display = 'none';
-        });
-
-        // Show tool cards container and search bar
-        if (toolCardsContainer) toolCardsContainer.style.display = 'flex'; // Bootstrap .row is display:flex
-        if (searchInput) searchInput.closest('.row').style.display = 'flex';
-    }
-
-    // Event listener for "Use Now" buttons (delegated from the container)
-    if (toolCardsContainer) {
-        toolCardsContainer.addEventListener('click', function(event) {
-            const target = event.target;
-            if (target.classList.contains('btn-use-now')) {
-                const toolId = target.getAttribute('data-tool-id');
-                if (toolId) {
-                    const toolDataEntry = toolsData.find(t => t.id === toolId || t.name.toLowerCase().replace(/\s+/g, '-') === toolId);
-                    if (toolDataEntry && document.getElementById(toolId)) { // Check if an implemented section exists
-                        showToolSection(toolId);
-                    } else if (toolId) { // If toolId exists but no section, it's a placeholder for an unimplemented tool
-                        window.location.href = 'coming-soon.html';
-                    }
-                }
-            }
-        });
-    }
-
-    // Event listener for all "Back to Tools" buttons
+    const backToToolsBtns = document.querySelectorAll('.back-to-tools-btn');
     if (backToToolsBtns) {
         backToToolsBtns.forEach(btn => {
-            btn.addEventListener('click', showToolsList);
+            // Ensure these are actual links <a> or handle navigation if they are <button>
+            // Assuming they are <a> tags as per the change in individual tool HTML files:
+            // No specific JS needed if they are <a href="tools.html">...</a>
+            // If they were buttons and we needed JS-based navigation:
+            // btn.addEventListener('click', function() {
+            //     window.location.href = 'tools.html';
+            // });
         });
     }
     // --- End Tool Navigation Logic ---

--- a/json-validator.html
+++ b/json-validator.html
@@ -6,9 +6,8 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 		<!-- SITE TITLE -->
-		<title>Free Tools - Sanjay Guthula</title>
+		<title>JSON Validator & Formatter - Sanjay Guthula</title>
 		<!-- Latest Bootstrap min CSS -->
 		<link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css">
 		<!-- Google Font -->
@@ -76,7 +75,7 @@
 
 					<ul class="mobile_menu">
 						<li><a href="index.html">Home</a></li>
-                        <li><a href="tools.html">Free Tools</a></li>
+                        <li class="current"><a href="tools.html">Free Tools</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="games.html">Games</a></li>
 						<li><a href="contact.html">Contact</a></li>
@@ -92,8 +91,8 @@
 				<div class="row">
 					<div class="col-xl-8 align-self-center wow fadeIn">
 						<div class="main_banner_content">
-							<span>Free Tools</span>
-							<h4>Explore Useful Tools & Resources</h4>
+							<span>Free Tools / Developer Tools</span>
+							<h4>JSON Validator & Formatter</h4>
 							<div class="ba_shape">
 								<svg fill="none" viewBox="0 0 16 141"><path fill="#fff" d="M10.387 11.014l4.886-9.945L3.727.939l4.66 10.053 2 .022zm-3.17 129.69a1 1 0 001.414.016l6.436-6.292a1 1 0 10-1.399-1.43l-5.72 5.592-5.592-5.72a1 1 0 00-1.43 1.398l6.291 6.436zM8.4 9.992L6.932 139.993l2 .023 1.466-130.002-2-.022z"/></svg>
 							</div>
@@ -101,40 +100,47 @@
 					</div><!-- End Col -->
 				</div>
 			</div>
-
 			<div class="bashape_1">
 				<img src="assets/img/shapes/banner-shape1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_2">
 				<img src="assets/img/shapes/star-1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_3">
 				<img src="assets/img/shapes/star-2.svg" alt="shape">
 			</div>
-
 		</section>
 		<!-- END Main Banner -->
 
 		<!-- START Tools Content -->
 		<section class="tools-content section-padding">
 			<div class="container">
-				<!-- Search Bar -->
-				<div class="row mb-4">
-					<div class="col-md-8 offset-md-2">
-						<div class="input-group">
-							<input type="text" id="toolSearchInput" class="form-control" placeholder="Search for tools by name or category (e.g., SEO, Text)...">
-							<button class="btn btn-outline-secondary" type="button" id="clearSearchBtn">Clear Search</button>
+				<!-- JSON Validator Tool Section -->
+				<div id="jsonValidatorToolSection" class="row mt-5">
+					<div class="col-12">
+						<div class="tool-container card">
+							<div class="card-body">
+								<div class="d-flex justify-content-between align-items-center mb-3">
+									<h4 class="card-title">JSON Validator & Formatter</h4>
+									<a href="tools.html" class="btn btn-sm btn-outline-secondary back-to-tools-btn">Back to Tools List</a>
+								</div>
+								<p>Paste your JSON data below to validate and format it.</p>
+								<div class="form-group">
+									<textarea id="jsonInputArea" class="form-control" rows="10" placeholder="Enter JSON here..."></textarea>
+								</div>
+								<button id="validateJsonBtn" class="btn btn-primary mt-3 mb-3">Validate & Format JSON</button>
+								<div id="jsonResultArea" class="mt-3">
+									<!-- Validation messages will appear here -->
+								</div>
+								<div id="formattedJsonContainer" class="mt-3" style="display: none;">
+									<h5>Formatted JSON:</h5>
+									<pre id="formattedJsonOutput" class="bg-light p-3 border rounded"></pre>
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>
-
-				<!-- Tool Cards Grid -->
-				<div id="toolCardsContainer" class="row">
-					<!-- Tool cards will be dynamically inserted here by JavaScript -->
-					<!-- Implemented tool sections (Word Counter, JSON Validator, SEO Meta Tag Checker) are now removed from here and exist on their own pages. -->
-				</div>
+				<!-- End JSON Validator Tool Section -->
 			</div>
 		</section>
 		<!-- END Tools Content -->

--- a/seo-meta-tag-checker.html
+++ b/seo-meta-tag-checker.html
@@ -6,9 +6,8 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 		<!-- SITE TITLE -->
-		<title>Free Tools - Sanjay Guthula</title>
+		<title>SEO Meta Tag Checker - Sanjay Guthula</title>
 		<!-- Latest Bootstrap min CSS -->
 		<link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css">
 		<!-- Google Font -->
@@ -76,7 +75,7 @@
 
 					<ul class="mobile_menu">
 						<li><a href="index.html">Home</a></li>
-                        <li><a href="tools.html">Free Tools</a></li>
+                        <li class="current"><a href="tools.html">Free Tools</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="games.html">Games</a></li>
 						<li><a href="contact.html">Contact</a></li>
@@ -92,8 +91,8 @@
 				<div class="row">
 					<div class="col-xl-8 align-self-center wow fadeIn">
 						<div class="main_banner_content">
-							<span>Free Tools</span>
-							<h4>Explore Useful Tools & Resources</h4>
+							<span>Free Tools / SEO</span>
+							<h4>SEO Meta Tag Checker</h4>
 							<div class="ba_shape">
 								<svg fill="none" viewBox="0 0 16 141"><path fill="#fff" d="M10.387 11.014l4.886-9.945L3.727.939l4.66 10.053 2 .022zm-3.17 129.69a1 1 0 001.414.016l6.436-6.292a1 1 0 10-1.399-1.43l-5.72 5.592-5.592-5.72a1 1 0 00-1.43 1.398l6.291 6.436zM8.4 9.992L6.932 139.993l2 .023 1.466-130.002-2-.022z"/></svg>
 							</div>
@@ -101,40 +100,43 @@
 					</div><!-- End Col -->
 				</div>
 			</div>
-
 			<div class="bashape_1">
 				<img src="assets/img/shapes/banner-shape1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_2">
 				<img src="assets/img/shapes/star-1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_3">
 				<img src="assets/img/shapes/star-2.svg" alt="shape">
 			</div>
-
 		</section>
 		<!-- END Main Banner -->
 
 		<!-- START Tools Content -->
 		<section class="tools-content section-padding">
 			<div class="container">
-				<!-- Search Bar -->
-				<div class="row mb-4">
-					<div class="col-md-8 offset-md-2">
-						<div class="input-group">
-							<input type="text" id="toolSearchInput" class="form-control" placeholder="Search for tools by name or category (e.g., SEO, Text)...">
-							<button class="btn btn-outline-secondary" type="button" id="clearSearchBtn">Clear Search</button>
+				<!-- SEO Meta Tag Checker Tool Section -->
+				<div id="seoMetaTagCheckerToolSection" class="row mt-5">
+					<div class="col-12">
+						<div class="tool-container card">
+							<div class="card-body">
+								<div class="d-flex justify-content-between align-items-center mb-3">
+									<h4 class="card-title">SEO Meta Tag Checker</h4>
+									<a href="tools.html" class="btn btn-sm btn-outline-secondary back-to-tools-btn">Back to Tools List</a>
+								</div>
+								<p>Paste your website's full HTML source code below to analyze its meta tags.</p>
+								<div class="form-group">
+									<textarea id="htmlInputArea" class="form-control" rows="12" placeholder="Paste HTML source code here..."></textarea>
+								</div>
+								<button id="analyzeMetaTagsBtn" class="btn btn-primary mt-3 mb-3">Analyze Meta Tags</button>
+								<div id="metaTagsResultArea" class="mt-3">
+									<!-- Meta tag analysis results will appear here -->
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>
-
-				<!-- Tool Cards Grid -->
-				<div id="toolCardsContainer" class="row">
-					<!-- Tool cards will be dynamically inserted here by JavaScript -->
-					<!-- Implemented tool sections (Word Counter, JSON Validator, SEO Meta Tag Checker) are now removed from here and exist on their own pages. -->
-				</div>
+				<!-- End SEO Meta Tag Checker Tool Section -->
 			</div>
 		</section>
 		<!-- END Tools Content -->

--- a/word-counter.html
+++ b/word-counter.html
@@ -6,9 +6,8 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
 		<!-- SITE TITLE -->
-		<title>Free Tools - Sanjay Guthula</title>
+		<title>Word Counter Tool - Sanjay Guthula</title>
 		<!-- Latest Bootstrap min CSS -->
 		<link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css">
 		<!-- Google Font -->
@@ -76,7 +75,7 @@
 
 					<ul class="mobile_menu">
 						<li><a href="index.html">Home</a></li>
-                        <li><a href="tools.html">Free Tools</a></li>
+                        <li class="current"><a href="tools.html">Free Tools</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="games.html">Games</a></li>
 						<li><a href="contact.html">Contact</a></li>
@@ -92,8 +91,8 @@
 				<div class="row">
 					<div class="col-xl-8 align-self-center wow fadeIn">
 						<div class="main_banner_content">
-							<span>Free Tools</span>
-							<h4>Explore Useful Tools & Resources</h4>
+							<span>Free Tools / Text Analysis</span>
+							<h4>Word Counter</h4>
 							<div class="ba_shape">
 								<svg fill="none" viewBox="0 0 16 141"><path fill="#fff" d="M10.387 11.014l4.886-9.945L3.727.939l4.66 10.053 2 .022zm-3.17 129.69a1 1 0 001.414.016l6.436-6.292a1 1 0 10-1.399-1.43l-5.72 5.592-5.592-5.72a1 1 0 00-1.43 1.398l6.291 6.436zM8.4 9.992L6.932 139.993l2 .023 1.466-130.002-2-.022z"/></svg>
 							</div>
@@ -101,40 +100,66 @@
 					</div><!-- End Col -->
 				</div>
 			</div>
-
 			<div class="bashape_1">
 				<img src="assets/img/shapes/banner-shape1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_2">
 				<img src="assets/img/shapes/star-1.svg" alt="shape">
 			</div>
-
 			<div class="bashape_3">
 				<img src="assets/img/shapes/star-2.svg" alt="shape">
 			</div>
-
 		</section>
 		<!-- END Main Banner -->
 
 		<!-- START Tools Content -->
 		<section class="tools-content section-padding">
 			<div class="container">
-				<!-- Search Bar -->
-				<div class="row mb-4">
-					<div class="col-md-8 offset-md-2">
-						<div class="input-group">
-							<input type="text" id="toolSearchInput" class="form-control" placeholder="Search for tools by name or category (e.g., SEO, Text)...">
-							<button class="btn btn-outline-secondary" type="button" id="clearSearchBtn">Clear Search</button>
+				<!-- Word Counter Tool Section -->
+				<div id="wordCounterToolSection" class="row mt-5">
+					<div class="col-12">
+						<div class="tool-container card">
+							<div class="card-body">
+								<div class="d-flex justify-content-between align-items-center mb-3">
+									<h4 class="card-title">Word Counter</h4>
+									<a href="tools.html" class="btn btn-sm btn-outline-secondary back-to-tools-btn">Back to Tools List</a>
+								</div>
+								<p>Enter your text below to count words, characters, sentences, and paragraphs. Also estimates reading time.</p>
+								<div class="form-group">
+									<textarea id="wordCounterInput" class="form-control" rows="10" placeholder="Start typing or paste your text here..."></textarea>
+								</div>
+								<div class="mt-3 mb-3 text-end">
+									<button id="clearTextBtn" class="btn btn-danger btn-sm">Clear Text</button>
+								</div>
+								<div class="row mt-3">
+									<div class="col-md-6 mb-2">
+										<p class="mb-0"><strong>Word Count:</strong> <span id="wordCountOutput" class="count-value">0</span></p>
+									</div>
+									<div class="col-md-6 mb-2">
+										<p class="mb-0">
+											<strong>Character Count:</strong>
+											<span id="charCountOutput" class="count-value">0</span>
+											<span class="ms-2">
+												<input type="checkbox" id="charCountIncludeSpacesToggle" checked>
+												<label for="charCountIncludeSpacesToggle" class="form-check-label small">Include Spaces</label>
+											</span>
+										</p>
+									</div>
+									<div class="col-md-6 mb-2">
+										<p class="mb-0"><strong>Sentence Count:</strong> <span id="sentenceCountOutput" class="count-value">0</span></p>
+									</div>
+									<div class="col-md-6 mb-2">
+										<p class="mb-0"><strong>Paragraph Count:</strong> <span id="paragraphCountOutput" class="count-value">0</span></p>
+									</div>
+									<div class="col-md-6 mb-2">
+										<p class="mb-0"><strong>Reading Time:</strong> <span id="readingTimeOutput" class="count-value">~0 min</span></p>
+									</div>
+								</div>
+							</div>
 						</div>
 					</div>
 				</div>
-
-				<!-- Tool Cards Grid -->
-				<div id="toolCardsContainer" class="row">
-					<!-- Tool cards will be dynamically inserted here by JavaScript -->
-					<!-- Implemented tool sections (Word Counter, JSON Validator, SEO Meta Tag Checker) are now removed from here and exist on their own pages. -->
-				</div>
+				<!-- End Word Counter Tool Section -->
 			</div>
 		</section>
 		<!-- END Tools Content -->


### PR DESCRIPTION
- I created individual HTML pages for Word Counter, JSON Validator, and SEO Meta Tag Checker.
- I moved tool-specific HTML sections from tools.html to their new dedicated pages.
- I updated tools.html to be a listing page; 'Use Now' buttons now link to the new individual tool pages.
- I adjusted tools-page.js to support both the listing page and individual tool pages:
  - The displayTools function now generates direct links.
  - Tool-specific JS logic remains conditional to avoid errors on pages where elements are not present.
  - I removed old same-page navigation JS from tools.html context.
- I ensured 'Back to Tools' buttons on individual pages link to tools.html.