### PR TITLE
Unhide about section image

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
 							<h2>Overview</h2>
 						</div>
 					</div><!-- End Col -->
-					<div class="col-xl-4 col-md-6 col-12 wow fadeIn" style="display: none;">
+					<div class="col-xl-4 col-md-6 col-12 wow fadeIn">
 						<div class="about-img">
 							<img src="assets/img/sanjay-guthula.jpg" alt="Sanjay - Digital Marketing Strategist">
 							<a href="contact.html" class="ab_btn">Hire Me <img src="assets/img/icons/arrow-up.svg" alt="arrow"></a>


### PR DESCRIPTION
The image in the about section of the home page was hidden with an inline style `display: none;`. This change removes the inline style to make the image visible.